### PR TITLE
feat: run js with fully functional text editor

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 require('dotenv').config();
 const cors = require('cors');
+const { spawn } = require("child_process");
 
 const database = require('./config/database');
 database.connect();
@@ -12,6 +13,39 @@ const router = require('./routes/client/index.route');
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cors());
+
+app.post("/execute", (req, res) => {
+  const { code } = req.body;
+
+  if (!code) {
+    return res.status(400).json({ error: "No code provided" });
+  }
+
+  // Run the JavaScript code securely inside Docker using stdin
+  const process = spawn("docker", ["run", "--rm", "-i", "secure-js-sandbox"]);
+
+  let output = "";
+  process.stdout.on("data", (data) => {
+    output += data.toString();
+  });
+
+  process.stderr.on("data", (data) => {
+    console.error("Error:", data.toString());
+  });
+
+  process.on("close", () => {
+    try {
+      const result = JSON.parse(output.trim());
+      res.json(result);
+    } catch (error) {
+      res.status(500).json({ error: "Invalid output format" });
+    }
+  });
+
+  // Send code to container via stdin
+  process.stdin.write(code + "\n");
+  process.stdin.end();
+});
 
 router(app);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "3"
+services:
+  sandbox:
+    build: ./sandbox

--- a/frontend/src/pages/live-code/CodeEditor.jsx
+++ b/frontend/src/pages/live-code/CodeEditor.jsx
@@ -1,6 +1,7 @@
 import './code-editor.scss'
 
 import Editor from "@monaco-editor/react";
+import axios from 'axios';
 import { useRef } from "react";
 
 function CodeEditor () {
@@ -10,13 +11,15 @@ function CodeEditor () {
     editorRef.current = editor;
   }
 
-  function showValue() {
-    alert(editorRef.current.getValue());
+  const execute = async () => {
+    const code = editorRef.current.getValue();
+    const response = await axios.post('http://localhost:3000/execute', {code: code})
+    console.log(response.data.logs)
   }
 
   return (
     <div className="code-editor">
-      <button onClick={showValue}>code editor</button>
+      <button onClick={execute}>Run code</button>
       <Editor
         height="90vh"
         defaultLanguage="javascript"

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+
+WORKDIR /sandbox
+COPY execute.js ./
+
+CMD ["node", "execute.js"]

--- a/sandbox/execute.js
+++ b/sandbox/execute.js
@@ -1,0 +1,31 @@
+const { Worker, isMainThread, parentPort } = require("worker_threads");
+
+if (isMainThread) {
+    process.stdin.on("data", (data) => {
+        const code = data.toString().trim();
+
+        const worker = new Worker(`
+            const { parentPort } = require('worker_threads');
+
+            try {
+                let logOutput = [];
+                const originalLog = console.log;
+                console.log = (...args) => {
+                    logOutput.push(args.join(" "));
+                };
+
+                eval(\`${code}\`); // Execute JS safely
+
+                parentPort.postMessage(
+                    logOutput.length > 0 ? { logs: logOutput } : {}
+                );
+            } catch (error) {
+                parentPort.postMessage({ error: error.message });
+            }
+        `, { eval: true });
+
+        worker.on("message", (msg) => {
+            console.log(JSON.stringify(msg));
+        });
+    });
+}


### PR DESCRIPTION
after the first pull, do `docker-compose up --build` 
the api to test is `http://localhost:3000/execute`

- **You only need to rebuild (`docker-compose up --build`) if you change `execute.js` or `Dockerfile`.**
- **For normal work, just use `docker-compose up`.**
- **Use `docker-compose down` to stop everything cleanly.**